### PR TITLE
[ADD] Added ServerIPv4 config field.

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -28,6 +28,7 @@ func init() {
 type PCFContext struct {
 	NfId            string
 	Name            string
+	ServerIPv4      string
 	UriScheme       models.UriScheme
 	HttpIPv4Address string
 	HttpIpv4Port    int

--- a/factory/config.go
+++ b/factory/config.go
@@ -19,6 +19,8 @@ type Info struct {
 type Configuration struct {
 	PcfName string `yaml:"pcfName,omitempty"`
 
+	ServerIPv4 string `yaml:"serverIPv4,omitempty"`
+
 	Sbi *Sbi `yaml:"sbi,omitempty"`
 
 	TimeFormat string `yaml:"timeFormat,omitempty"`

--- a/service/init.go
+++ b/service/init.go
@@ -126,7 +126,7 @@ func (pcf *PCF) Start() {
 	self := context.PCF_Self()
 	util.InitpcfContext(self)
 
-	addr := fmt.Sprintf("%s:%d", self.HttpIPv4Address, self.HttpIpv4Port)
+	addr := fmt.Sprintf("%s:%d", self.ServerIPv4, self.HttpIpv4Port)
 
 	profile, err := consumer.BuildNFInstance(self)
 	if err != nil {

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -6,6 +6,7 @@ import (
 	"free5gc/src/pcf/context"
 	"free5gc/src/pcf/factory"
 	"free5gc/src/pcf/logger"
+	"os"
 
 	"github.com/google/uuid"
 )
@@ -18,6 +19,15 @@ func InitpcfContext(context *context.PCFContext) {
 	context.NfId = uuid.New().String()
 	if configuration.PcfName != "" {
 		context.Name = configuration.PcfName
+	}
+	context.ServerIPv4 = os.Getenv(configuration.ServerIPv4)
+	if context.ServerIPv4 == "" {
+		logger.UtilLog.Warn("Problem parsing ServerIPv4 address from ENV Variable. Trying to parse it as string.")
+		context.ServerIPv4 = configuration.ServerIPv4
+		if context.ServerIPv4 == "" {
+			logger.UtilLog.Warn("Error parsing ServerIPv4 address as string. Using the localhost address as default.")
+			context.ServerIPv4 = "127.0.0.1"
+		}
 	}
 	sbi := configuration.Sbi
 	context.NrfUri = configuration.NrfUri


### PR DESCRIPTION
The `ServerIPv4` field will be used to specify the IP where the server will start.
The difference that this field makes is that now the NFs can advertise a service IP (which is different from the NodeIP) in Kubernetes.

These modifications were tested and no compatibility issues were found.

This PR comes after the discussion here: https://github.com/free5gc/free5gc/issues/49#issuecomment-640213366