### PR TITLE
Add locality in config and NF Profile of PCF

### DIFF
--- a/consumer/nf_management.go
+++ b/consumer/nf_management.go
@@ -39,6 +39,9 @@ func BuildNFInstance(context *pcf_context.PCFContext) (profile models.NfProfile,
 		// 	},
 		// },
 	}
+	if context.Locality != "" {
+		profile.Locality = context.Locality
+	}
 	return
 }
 

--- a/context/context.go
+++ b/context/context.go
@@ -42,6 +42,7 @@ type PCFContext struct {
 	PcfSuppFeats    map[models.ServiceName]openapi.SupportedFeature
 	NrfUri          string
 	DefaultUdrURI   string
+	Locality        string
 	// UePool          map[string]*UeContext
 	UePool sync.Map
 	// Bdt Policy related

--- a/factory/config.go
+++ b/factory/config.go
@@ -37,6 +37,7 @@ type Configuration struct {
 	NrfUri          string    `yaml:"nrfUri,omitempty"`
 	ServiceList     []Service `yaml:"serviceList,omitempty"`
 	Mongodb         *Mongodb  `yaml:"mongodb"`
+	Locality        string    `yaml:"locality,omitempty"`
 }
 
 type Service struct {

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -72,4 +72,5 @@ func InitpcfContext(context *context.PCFContext) {
 			logger.UtilLog.Errorf("openapi NewSupportedFeature error: %+v", err)
 		}
 	}
+	context.Locality = configuration.Locality
 }


### PR DESCRIPTION
This PR adds locality in the NF Profile of PCF.
If locality is missing, PCF registers to NRF in a similar way so far.
