### PR TITLE
Fix: ratingGroup map with smPolicyId and refactor allocation and release

### DIFF
--- a/internal/context/ue.go
+++ b/internal/context/ue.go
@@ -36,6 +36,9 @@ type UeContext struct {
 	AppSessionIdStore           *AppSessionIdStore
 	PolicyDataSubscriptionStore *models.PolicyDataSubscription
 	PolicyDataChangeStore       *models.PolicyDataChangeNotification
+
+	// ChargingRatingGroup
+	RatingGroupData map[string][]int32 // use smPolicyId(ue.Supi-pduSessionId) as key
 }
 
 type UeAMPolicyData struct {

--- a/internal/sbi/producer/smpolicy.go
+++ b/internal/sbi/producer/smpolicy.go
@@ -271,8 +271,9 @@ func createSMPolicyProcedure(request models.SmPolicyContextData) (
 		util.SetPccRuleRelatedData(&decision, pcc, nil, nil, chgData, nil)
 
 		chargingInterface["ratingGroup"] = chgData.RatingGroup
-		logger.SmPolicyLog.Traceln("put ratingGroup to MongoDB")
-		if _, err = mongoapi.RestfulAPIPutOne(chargingDataColl, chargingInterface, chargingInterface); err != nil {
+		logger.SmPolicyLog.Tracef("put ratingGroup[%+v] for [%+v] to MongoDB", chgData.RatingGroup, ue.Supi)
+		if _, err = mongoapi.RestfulAPIPutOne(
+			chargingDataColl, chargingInterface, chargingInterface, queryStrength); err != nil {
 			logger.SmPolicyLog.Errorf("Fail to put charging data to mongoDB err: %+v", err)
 		}
 		if ue.RatingGroupData == nil {
@@ -368,7 +369,9 @@ func createSMPolicyProcedure(request models.SmPolicyContextData) (
 				}
 
 				chargingInterface["ratingGroup"] = chgData.RatingGroup
-				if _, err = mongoapi.RestfulAPIPutOne(chargingDataColl, chargingInterface, chargingInterface); err != nil {
+				logger.SmPolicyLog.Tracef("put ratingGroup[%+v] for [%+v] to MongoDB", chgData.RatingGroup, ue.Supi)
+				if _, err = mongoapi.RestfulAPIPutOne(
+					chargingDataColl, chargingInterface, chargingInterface, queryStrength); err != nil {
 					logger.SmPolicyLog.Errorf("Fail to put charging data to mongoDB err: %+v", err)
 				} else {
 					util.SetPccRuleRelatedData(&decision, pccRule, nil, nil, chgData, nil)

--- a/internal/sbi/producer/smpolicy.go
+++ b/internal/sbi/producer/smpolicy.go
@@ -560,6 +560,7 @@ func deleteSmPolicyContextProcedure(smPolicyID string) *models.ProblemDetails {
 			logger.SmPolicyLog.Errorf("Fail to delete charging data, ratingGroup: %+v, err: %+v", ratingGroup, err)
 		}
 	}
+	delete(ue.RatingGroupData, smPolicyID)
 	return nil
 }
 

--- a/internal/sbi/producer/smpolicy.go
+++ b/internal/sbi/producer/smpolicy.go
@@ -272,7 +272,7 @@ func createSMPolicyProcedure(request models.SmPolicyContextData) (
 
 		chargingInterface["ratingGroup"] = chgData.RatingGroup
 		logger.SmPolicyLog.Traceln("put ratingGroup to MongoDB")
-		if err = mongoapi.RestfulAPIPostMany(chargingDataColl, nil, []interface{}{chargingInterface}); err != nil {
+		if _, err = mongoapi.RestfulAPIPutOne(chargingDataColl, chargingInterface, chargingInterface); err != nil {
 			logger.SmPolicyLog.Errorf("Fail to put charging data to mongoDB err: %+v", err)
 		}
 		if ue.RatingGroupData == nil {
@@ -368,7 +368,7 @@ func createSMPolicyProcedure(request models.SmPolicyContextData) (
 				}
 
 				chargingInterface["ratingGroup"] = chgData.RatingGroup
-				if err = mongoapi.RestfulAPIPostMany(chargingDataColl, nil, []interface{}{chargingInterface}); err != nil {
+				if _, err = mongoapi.RestfulAPIPutOne(chargingDataColl, chargingInterface, chargingInterface); err != nil {
 					logger.SmPolicyLog.Errorf("Fail to put charging data to mongoDB err: %+v", err)
 				} else {
 					util.SetPccRuleRelatedData(&decision, pccRule, nil, nil, chgData, nil)
@@ -555,7 +555,7 @@ func deleteSmPolicyContextProcedure(smPolicyID string) *models.ProblemDetails {
 		filterCharging := bson.M{
 			"ratingGroup": ratingGroup,
 		}
-		err := mongoapi.RestfulAPIDeleteOne(chargingDataColl, filterCharging)
+		err := mongoapi.RestfulAPIDeleteMany(chargingDataColl, filterCharging)
 		if err != nil {
 			logger.SmPolicyLog.Errorf("Fail to delete charging data, ratingGroup: %+v, err: %+v", ratingGroup, err)
 		}


### PR DESCRIPTION
## Description
- Create a new chargingData record to MongoDB
- release ratingGroup when SMPolicy release
  - delete the corresponding record from MongoDB 