### PR TITLE
fix: modify default flow direction to bidirectional

### DIFF
--- a/internal/util/pcc_rule.go
+++ b/internal/util/pcc_rule.go
@@ -25,7 +25,7 @@ func CreateDefaultPccRules(id int32) *models.PccRule {
 	flowInfo := []models.FlowInformation{
 		{
 			FlowDescription:   "permit out ip from any to assigned",
-			FlowDirection:     models.FlowDirectionRm_DOWNLINK,
+			FlowDirection:     models.FlowDirectionRm_BIDIRECTIONAL,
 			PacketFilterUsage: true,
 			PackFiltId:        "PackFiltId-0",
 		},


### PR DESCRIPTION
This PR is to solve problem 4 of issue [#627](https://github.com/free5gc/free5gc/issues/627).
According to TS 24.501 6.2.5.1.1.2, I modify the flow direction of the default PCC rule from downlink to bidirectional.
![image](https://github.com/user-attachments/assets/0bf345f1-bf83-4e3e-8160-f33231eddf36)
