### PR TITLE
fix: delete InfluenceDataToPccRule

### DIFF
--- a/internal/context/ue.go
+++ b/internal/context/ue.go
@@ -268,7 +268,6 @@ func (policy *UeSmPolicyData) RemovePccRule(pccRuleId string, deletedSmPolicyDec
 				delete(policy.InfluenceDataToPccRule, influenceID)
 			}
 		}
-
 	} else {
 		return fmt.Errorf("can't find the pccRuleId[%s] in Session[%d]", pccRuleId, policy.PolicyContext.PduSessionId)
 	}

--- a/internal/context/ue.go
+++ b/internal/context/ue.go
@@ -262,6 +262,13 @@ func (policy *UeSmPolicyData) RemovePccRule(pccRuleId string, deletedSmPolicyDec
 			}
 		}
 		delete(decision.PccRules, pccRuleId)
+
+		for influenceID, mappedPccRuleId := range policy.InfluenceDataToPccRule {
+			if mappedPccRuleId == pccRuleId {
+				delete(policy.InfluenceDataToPccRule, influenceID)
+			}
+		}
+
 	} else {
 		return fmt.Errorf("can't find the pccRuleId[%s] in Session[%d]", pccRuleId, policy.PolicyContext.PduSessionId)
 	}


### PR DESCRIPTION
This pull request is for fixing issue [#958](https://github.com/free5gc/free5gc/issues/958).

`RemovePccRule` method in `internal/context/ue.go` deletes the PCC rule and related data, but never purges `InfluenceDataToPccRule`, so other deletion paths can leave stale influence→rule pointers.

Fix:

* Updated the function `RemovePccRule` to remove any entries in the `InfluenceDataToPccRule` map that point to the deleted PCC rule, ensuring data consistency when a PCC rule is removed.