### PR TITLE
fix: stale PCC rule reference

### DIFF
--- a/internal/context/ue.go
+++ b/internal/context/ue.go
@@ -262,6 +262,28 @@ func (policy *UeSmPolicyData) RemovePccRule(pccRuleId string, deletedSmPolicyDec
 			}
 		}
 		delete(decision.PccRules, pccRuleId)
+		// Prune stale references from related app-sessions.
+		for appSessionId := range policy.AppSessions {
+			if val, ok := GetSelf().AppSessionPool.Load(appSessionId); ok {
+				appSession := val.(*AppSessionData)
+				if appSession.RelatedPccRuleIds != nil {
+					for key, relatedId := range appSession.RelatedPccRuleIds {
+						if relatedId == pccRuleId {
+							delete(appSession.RelatedPccRuleIds, key)
+						}
+					}
+					if len(appSession.RelatedPccRuleIds) == 0 {
+						appSession.RelatedPccRuleIds = nil
+					}
+				}
+				if appSession.PccRuleIdMapToCompId != nil {
+					delete(appSession.PccRuleIdMapToCompId, pccRuleId)
+					if len(appSession.PccRuleIdMapToCompId) == 0 {
+						appSession.PccRuleIdMapToCompId = nil
+					}
+				}
+			}
+		}
 
 		for influenceID, mappedPccRuleId := range policy.InfluenceDataToPccRule {
 			if mappedPccRuleId == pccRuleId {

--- a/internal/sbi/processor/policyauthorization.go
+++ b/internal/sbi/processor/policyauthorization.go
@@ -982,15 +982,15 @@ func (p *Processor) HandleUpdateEventsSubscContext(
 	}
 
 	resp := models.EventsSubscPutData{
-		Events:                    eventsSubscReqData.Events,
-		NotifUri:                  eventsSubscReqData.NotifUri,
-		ReqQosMonParams:           eventsSubscReqData.ReqQosMonParams,
-		QosMon:                    eventsSubscReqData.QosMon,
-		ReqAnis:                   eventsSubscReqData.ReqAnis,
-		UsgThres:                  eventsSubscReqData.UsgThres,
-		NotifCorreId:              eventsSubscReqData.NotifCorreId,
-		AfAppIds:                  eventsSubscReqData.AfAppIds,
-		DirectNotifInd:            eventsSubscReqData.DirectNotifInd,
+		Events:          eventsSubscReqData.Events,
+		NotifUri:        eventsSubscReqData.NotifUri,
+		ReqQosMonParams: eventsSubscReqData.ReqQosMonParams,
+		QosMon:          eventsSubscReqData.QosMon,
+		ReqAnis:         eventsSubscReqData.ReqAnis,
+		UsgThres:        eventsSubscReqData.UsgThres,
+		NotifCorreId:    eventsSubscReqData.NotifCorreId,
+		AfAppIds:        eventsSubscReqData.AfAppIds,
+		DirectNotifInd:  eventsSubscReqData.DirectNotifInd,
 	}
 	if appSessCtx.EvsNotif != nil {
 		resp.AccessType = appSessCtx.EvsNotif.AccessType

--- a/internal/sbi/processor/policyauthorization.go
+++ b/internal/sbi/processor/policyauthorization.go
@@ -991,15 +991,17 @@ func (p *Processor) HandleUpdateEventsSubscContext(
 		NotifCorreId:              eventsSubscReqData.NotifCorreId,
 		AfAppIds:                  eventsSubscReqData.AfAppIds,
 		DirectNotifInd:            eventsSubscReqData.DirectNotifInd,
-		AccessType:                appSessCtx.EvsNotif.AccessType,
-		AnGwAddr:                  appSessCtx.EvsNotif.AnGwAddr,
-		EvSubsUri:                 appSessCtx.EvsNotif.EvSubsUri,
-		EvNotifs:                  appSessCtx.EvsNotif.EvNotifs,
-		FailedResourcAllocReports: appSessCtx.EvsNotif.FailedResourcAllocReports,
-		PlmnId:                    appSessCtx.EvsNotif.PlmnId,
-		QncReports:                appSessCtx.EvsNotif.QncReports,
-		RatType:                   appSessCtx.EvsNotif.RatType,
-		UsgRep:                    appSessCtx.EvsNotif.UsgRep,
+	}
+	if appSessCtx.EvsNotif != nil {
+		resp.AccessType = appSessCtx.EvsNotif.AccessType
+		resp.AnGwAddr = appSessCtx.EvsNotif.AnGwAddr
+		resp.EvSubsUri = appSessCtx.EvsNotif.EvSubsUri
+		resp.EvNotifs = appSessCtx.EvsNotif.EvNotifs
+		resp.FailedResourcAllocReports = appSessCtx.EvsNotif.FailedResourcAllocReports
+		resp.PlmnId = appSessCtx.EvsNotif.PlmnId
+		resp.QncReports = appSessCtx.EvsNotif.QncReports
+		resp.RatType = appSessCtx.EvsNotif.RatType
+		resp.UsgRep = appSessCtx.EvsNotif.UsgRep
 	}
 
 	changed := appSession.SmPolicyData.ArrangeExistEventSubscription()


### PR DESCRIPTION
This pull request fixes issue free5gc/free5gc#959. 

An app-session stored `RelatedPccRuleIds` pointing into the associated `smPolicy.PolicyDecision.PccRules`. Later, SM policy deletes a PCC rule, but the app-session still keeps that PCC rule ID. 
When you perform `PUT /events-subscription`, PCF does: `pccRule := smPolicy.PolicyDecision.PccRules[pccRuleID]` then iterates `pccRule.RefQosData`.
If the PCC rule is gone, pccRule is nil → nil pointer deref → 500 panic.

There's an additional bug found,  In `PUT /events-subscription`, the code sets `appSessCtx.EvsNotif = nil` if there are no `EvNotifs`. For a QOS_NOTIF-only subscription, no `EvNotifs` are appended, so `EvsNotif` becomes `nil`. 
Immediately after, it built a `models.EventsSubscPutData` response by dereferencing `appSessCtx.EvsNotif.AccessType` ... → nil pointer dereference. 

Fixes:

* When a PCC rule is removed in `RemovePccRule`, the code now also prunes any stale references to the deleted PCC rule from related application sessions, including both `RelatedPccRuleIds` and `PccRuleIdMapToCompId` fields.

* In `HandleUpdateEventsSubscContext`, the assignment of event notification fields to the response object is now conditional on `EvsNotif` being non-nil. This prevents potential nil pointer dereferences and ensures that only valid data is copied.