### PR TITLE
fix: reinforce AM policy creation

### DIFF
--- a/internal/context/ue.go
+++ b/internal/context/ue.go
@@ -400,6 +400,9 @@ func (ue *UeContext) FindAMPolicy(anType models.AccessType, plmnId *models.PlmnI
 		return nil
 	}
 	for _, amPolicy := range ue.AMPolicyData {
+		if amPolicy == nil || amPolicy.ServingPlmn == nil {
+			continue
+		}
 		if amPolicy.AccessType == anType && reflect.DeepEqual(*amPolicy.ServingPlmn, *plmnId) {
 			return amPolicy
 		}

--- a/internal/context/ue.go
+++ b/internal/context/ue.go
@@ -401,6 +401,7 @@ func (ue *UeContext) FindAMPolicy(anType models.AccessType, plmnId *models.PlmnI
 	}
 	for _, amPolicy := range ue.AMPolicyData {
 		if amPolicy == nil || amPolicy.ServingPlmn == nil {
+			logger.CtxLog.Warnln("AM Policy or ServingPlmn is nil")
 			continue
 		}
 		if amPolicy.AccessType == anType && reflect.DeepEqual(*amPolicy.ServingPlmn, *plmnId) {

--- a/internal/sbi/api_ampolicy.go
+++ b/internal/sbi/api_ampolicy.go
@@ -120,7 +120,9 @@ func (s *Server) HTTPCreateIndividualAMPolicyAssociation(c *gin.Context) {
 		return
 	}
 
-	if policyAssociationRequest.Supi == "" || policyAssociationRequest.NotificationUri == "" || policyAssociationRequest.ServingPlmn == nil {
+	if policyAssociationRequest.Supi == "" ||
+		policyAssociationRequest.NotificationUri == "" ||
+		policyAssociationRequest.ServingPlmn == nil {
 		rsp := util.GetProblemDetail("Missing Mandatory IE", util.ERROR_REQUEST_PARAMETERS)
 		logger.AmPolicyLog.Errorln(rsp.Detail)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)

--- a/internal/sbi/api_ampolicy.go
+++ b/internal/sbi/api_ampolicy.go
@@ -120,7 +120,8 @@ func (s *Server) HTTPCreateIndividualAMPolicyAssociation(c *gin.Context) {
 		return
 	}
 
-	if policyAssociationRequest.Supi == "" || policyAssociationRequest.NotificationUri == "" {
+	if policyAssociationRequest.Supi == "" || policyAssociationRequest.NotificationUri == "" || 
+		policyAssociationRequest.ServingPlmn == nil {
 		rsp := util.GetProblemDetail("Missing Mandatory IE", util.ERROR_REQUEST_PARAMETERS)
 		logger.AmPolicyLog.Errorln(rsp.Detail)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)

--- a/internal/sbi/api_ampolicy.go
+++ b/internal/sbi/api_ampolicy.go
@@ -120,8 +120,7 @@ func (s *Server) HTTPCreateIndividualAMPolicyAssociation(c *gin.Context) {
 		return
 	}
 
-	if policyAssociationRequest.Supi == "" || policyAssociationRequest.NotificationUri == "" || 
-		policyAssociationRequest.ServingPlmn == nil {
+	if policyAssociationRequest.Supi == "" || policyAssociationRequest.NotificationUri == "" || policyAssociationRequest.ServingPlmn == nil {
 		rsp := util.GetProblemDetail("Missing Mandatory IE", util.ERROR_REQUEST_PARAMETERS)
 		logger.AmPolicyLog.Errorln(rsp.Detail)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)


### PR DESCRIPTION
This pull request fixes issue free5gc/free5gc#960.

PCF allows `npcf-am-policy-control` to create an AM policy without `servingPlmn`, which can later caused server panic when `FindAMPolicy` is called.

Fixes:

* Added a check to ensure `ServingPlmn` is not nil in the `HTTPCreateIndividualAMPolicyAssociation` handler, preventing the creation of AM Policy associations with missing mandatory fields.
* Updated the `FindAMPolicy` method in `UeContext` to skip over any nil `AMPolicyData` entries or entries with a nil `ServingPlmn`, reducing the risk of runtime errors.